### PR TITLE
Change the exit code to a constant for windows

### DIFF
--- a/src/fosslight_prechecker/_precheck.py
+++ b/src/fosslight_prechecker/_precheck.py
@@ -237,7 +237,7 @@ def run_lint(target_path, disable, output_file_name, format='', need_log_file=Tr
     global _turn_on_default_reuse_config, _check_only_file_mode, _start_time
 
     file_to_check_list = []
-    _exit_code = os.EX_OK
+    _exit_code = 0
     path_to_find = ""
     report = ProjectReport()
     result_item = ResultItem()

--- a/src/fosslight_prechecker/_result.py
+++ b/src/fosslight_prechecker/_result.py
@@ -22,7 +22,7 @@ CUSTOMIZED_FORMAT_FOR_PRECHECKER = {'html': '.html', 'xml': '.xml', 'yaml': '.ya
 RULE_LINK = "https://oss.lge.com/guide/process/osc_process/1-identification/copyright_license_rule.html"
 MSG_REFERENCE = "Ref. Copyright and License Writing Rules in Source Code. : " + RULE_LINK
 MSG_FOLLOW_LIC_TXT = "Follow the Copyright and License Writing Rules in Source Code. : " + RULE_LINK
-
+EX_IOERR = 74
 logger = logging.getLogger(constant.LOGGER_NAME)
 
 
@@ -151,7 +151,7 @@ def write_result_xml(result_file: str, exit_code: int, result_item: ResultItem, 
         success = True
     except Exception as ex:
         logger.error(f"Error_to_write_xml: {ex}")
-        exit_code = os.EX_IOERR
+        exit_code = EX_IOERR
     return success, exit_code
 
 
@@ -166,7 +166,7 @@ def write_result_html(result_file: str, exit_code: int, result_item: ResultItem,
         success = True
     except Exception as ex:
         logger.error(f"Error_to_write_html: {ex}")
-        exit_code = os.EX_IOERR
+        exit_code = EX_IOERR
     return success, exit_code
 
 
@@ -182,7 +182,7 @@ def write_result_yaml(result_file: str, exit_code: int, result_item: ResultItem)
         success = True
     except Exception as ex:
         logger.error(f"Error_to_write_yaml: {ex}")
-        exit_code = os.EX_IOERR
+        exit_code = EX_IOERR
     return success, exit_code
 
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Change the exit code to a constant for windows support.
- os.EX_** : Exit Code is for UNIX. (https://docs.python.org/3/library/os.html)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

