### PR TITLE
Fix not to print argparse's help msg

### DIFF
--- a/src/fosslight_prechecker/cli.py
+++ b/src/fosslight_prechecker/cli.py
@@ -14,7 +14,7 @@ from fosslight_prechecker._add import add_content
 
 def main():
     parser = argparse.ArgumentParser(description='FOSSLight Prechecker', prog='fosslight_prechecker', add_help=False)
-    parser.add_argument('mode', nargs='?', help='lint | convert | add', default="")
+    parser.add_argument('mode', nargs='?', help='lint | convert | add', choices=['lint', 'convert', 'add'])
     parser.add_argument('--path', '-p', help='Path to check', type=str, dest='path', default="")
     parser.add_argument('--format', '-f', help='Format of ouput', type=str, dest='format', default="")
     parser.add_argument('--output', '-o', help='Output file name', type=str, dest='output', default="")
@@ -25,11 +25,11 @@ def main():
     parser.add_argument('--ignore', '-i', help='Do not write log to file', action='store_false', dest='log')
     parser.add_argument('--version', '-v', help='Print FOSSLight Prechecker version', action='store_true', dest='version')
     try:
-        args = parser.parse_args()
+        args, unknown = parser.parse_known_args()
     except SystemExit:
         print_help_msg()
 
-    if args.help:
+    if args.help or unknown:
         print_help_msg()
 
     if args.version:


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Fix not to print argparse's help msg when command error

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

