### PR TITLE
Modify to run all mode on Windows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -60,7 +60,7 @@ jobs:
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
-                pyinstaller --onefile cli.py -n cli --additional-hooks-dir=hooks --add-binary "LICENSE;LICENSES" --add-binary "LICENSES\LicenseRef-3rd_party_licenses.txt;LICENSES" &&
+                pyinstaller --onefile cli.py -n cli --additional-hooks-dir=hooks --collect-data reuse --add-binary "LICENSE;LICENSES" --add-binary "LICENSES\LicenseRef-3rd_party_licenses.txt;LICENSES" &&
                 move dist/cli.exe fosslight_prechecker_windows.exe
             OUT_FILE_NAME: fosslight_prechecker_windows.exe
             ASSET_MIME: application/vnd.microsoft.portable-executable

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,11 +45,11 @@ jobs:
             ASSET_MIME: application/octet-stream
           - os: windows-latest
             TARGET: windows
-            CMD_BUILD: >
-                pyinstaller --onefile cli.py -n cli --additional-hooks-dir=hooks &&
+            CMD_BUILD: |
+                tox -e windows
+                pyinstaller --onefile cli.py -n cli --additional-hooks-dir=hooks --collect-data reuse &&
                 move dist/cli.exe fosslight_prechecker_windows.exe &&
                 ./fosslight_prechecker_windows.exe
-                tox -e windows
             OUT_FILE_NAME: fosslight_prechecker_windows.exe
             ASSET_MIME: application/vnd.microsoft.portable-executable
     steps:

--- a/cli.py
+++ b/cli.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020 LG Electronics Inc.
 # SPDX-License-Identifier: GPL-3.0-only
-from fosslight_oss_pkg._convert import convert_report
+import multiprocessing
+from fosslight_prechecker.cli import main
 
 if __name__ == '__main__':
-    convert_report("", "", "")
+    multiprocessing.freeze_support()
+    main()

--- a/src/fosslight_prechecker/_precheck.py
+++ b/src/fosslight_prechecker/_precheck.py
@@ -119,14 +119,10 @@ def find_oss_pkg_info_and_exlcude_file(path, mode='lint'):
                 elif _turn_on_exclude_config and file.startswith('.'):
                     DEFAULT_EXCLUDE_EXTENSION_FILES.append(file_rel_path)
                 elif is_binary(file_abs_path):
-                    if is_windows:
-                        file_rel_path = file_rel_path.replace(os.sep, '/')
                     DEFAULT_EXCLUDE_EXTENSION_FILES.append(file_rel_path)
                 else:
                     extension = file_lower_case.split(".")[-1]
                     if extension in DEFAULT_EXCLUDE_EXTENSION:
-                        if is_windows:
-                            file_rel_path = file_rel_path.replace(os.sep, '/')
                         DEFAULT_EXCLUDE_EXTENSION_FILES.append(file_rel_path)
     except Exception as ex:
         dump_error_msg(f"Error_FIND_OSS_PKG : {ex}")
@@ -159,6 +155,10 @@ def create_reuse_dep5_file(path):
 
         DEFAULT_EXCLUDE_EXTENSION_FILES.extend(_DEFAULT_EXCLUDE_FOLDERS)
         exclude_file_list = list(set(DEFAULT_EXCLUDE_EXTENSION_FILES))
+
+        if is_windows:
+            exclude_file_list = [file.replace(os.sep, '/') for file in exclude_file_list]
+
         for file_to_exclude in exclude_file_list:
             str_contents += f"\nFiles: {file_to_exclude} \nCopyright: -\nLicense: -\n"
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Modify to run all mode on Windows
- Replace windows path separator '\\' to '/' when write .dep5 file

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

