### PR TITLE
Fix Dep5 encoding error

### DIFF
--- a/src/fosslight_prechecker/_precheck.py
+++ b/src/fosslight_prechecker/_precheck.py
@@ -162,7 +162,7 @@ def create_reuse_dep5_file(path):
         for file_to_exclude in exclude_file_list:
             str_contents += f"\nFiles: {file_to_exclude} \nCopyright: -\nLicense: -\n"
 
-        with open(reuse_config_file, "a") as f:
+        with open(reuse_config_file, "a", encoding="utf8") as f:
             if not need_rollback:
                 f.write(_DEFAULT_CONFIG_PREFIX)
             f.write(str_contents)


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix Dep5 encoding error.
- How to reproduce the bug : If you run the executable created with pyinstaller on windows, it will be reproduced. This bug causes the total file count to be less than the unlicensed file count.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

