### PR TITLE
Add git ignore option(-c) for excluding

### DIFF
--- a/src/fosslight_prechecker/_precheck.py
+++ b/src/fosslight_prechecker/_precheck.py
@@ -55,7 +55,7 @@ def exclude_gitignore_files(current_path, path):
         if os.path.isfile(os.path.join(root_path, '.gitignore')):
             cmd_result = subprocess.check_output(['git',
                                                   'ls-files',
-                                                  '-i',
+                                                  '-ci',
                                                   '--exclude-from=.gitignore'],
                                                  universal_newlines=True)
             cmd_result = cmd_result.split('\n')


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Add git ignore option(-c) for excluding
    - -c, --cached optioin : show cached files in the output (default)
        - on Windows, It occurs to error to get files in .gitignore without -c option
        - on Ubuntu, it's possible to get files in .gitginore regardless of -c option


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

