### PR TITLE
Add 'Download' mode to download license text

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ reuse==1.1.2
 PyYAML
 fosslight_util>=2.1.10
 jinja2
+pyaskalono

--- a/src/fosslight_prechecker/_download_lic.py
+++ b/src/fosslight_prechecker/_download_lic.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 LG Electronics Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+import os
+import urllib.request
+import logging
+import fosslight_util.constant as constant
+import shutil
+from pathlib import Path
+from askalono import identify
+from bs4 import BeautifulSoup
+from reuse.project import Project
+from reuse.download import run as reuse_download
+from fosslight_util.parsing_yaml import find_sbom_yaml_files, parsing_yml
+from fosslight_prechecker._add_header import reuse_parser
+from fosslight_prechecker._add import check_input_license_format, get_spdx_license_list, spdx_licenses
+from fosslight_prechecker._precheck import dump_error_msg, get_path_to_find
+
+
+OPENSOURCE_LGE_COM_URL_PREFIX = "https://opensource.lge.com/license/"
+LICENSE_INCLUDE_FILES = ["license", "license.md", "license.txt", "notice"]
+ASKALONO_THRESHOLD = 0.7
+
+logger = logging.getLogger(constant.LOGGER_NAME)
+
+
+def download_license(target_path: str, input_license: str) -> None:
+    _check_only_file_mode = False
+    path_to_find, _, _check_only_file_mode = get_path_to_find(target_path, _check_only_file_mode)
+
+    get_spdx_license_list()
+
+    # Download license text file of OSS-pkg-info.yaml
+    download_oss_info_license(path_to_find)
+
+    # Find and create representative license file
+    if input_license:
+        find_representative_license(path_to_find, input_license)
+
+def lge_lic_download(path_to_find: str, input_license: str) -> bool:
+    success = False
+
+    input_license_url = input_license.replace(' ', '_').replace('/', '_').replace('LicenseRef-', '').replace('-', '_')
+    lic_url = OPENSOURCE_LGE_COM_URL_PREFIX + input_license_url + ".html"
+
+    try:
+        html = urllib.request.urlopen(lic_url)
+        source = html.read()
+        html.close()
+    except urllib.error.URLError:
+        logger.error("Invalid URL address")
+    except ValueError as val_err:
+        logger.error(f"Invalid Value : {val_err}")
+    except Exception as ex:
+        logger.error(f"Error to open url - {lic_url} : {ex}")
+
+    soup = BeautifulSoup(source, 'html.parser')
+    try:
+        lic_text = soup.find("p", "bdTop")
+        Path(os.path.join(os.getcwd(), path_to_find, 'LICENSES')).mkdir(parents=True, exist_ok=True)
+        lic_file_path = os.path.join(path_to_find, 'LICENSES', f'{input_license}.txt')
+
+        with open(lic_file_path, 'w', encoding='utf-8') as f:
+            f.write(lic_text.get_text(separator='\n'))
+        if os.path.isfile(lic_file_path):
+            logger.info(f"Successfully downloaded {lic_file_path}")
+            success = True
+    except Exception as ex:
+        logger.error(f"Error to download license from LGE : {ex}")
+    return success
+
+
+def present_license_file(path_to_find: str, lic: str) -> bool:
+    present = False
+    lic_file_path = os.path.join(os.getcwd(), path_to_find, 'LICENSES')
+    file_name = f"{lic}.txt"
+    if file_name in os.listdir(lic_file_path):
+        present = True
+    return present
+
+
+def download_oss_info_license(base_path: str = "") -> None:
+    license_list = []
+    converted_lic_list = []
+    oss_yaml_files = []
+    main_parser = reuse_parser()
+    prj = Project(base_path)
+
+    oss_yaml_files = find_sbom_yaml_files(base_path)
+
+    if oss_yaml_files is None or len(oss_yaml_files) == 0:
+        logger.info("\n # There is no OSS package Info file in this path\n")
+        return
+    else:
+        logger.info(f"\n # There is OSS Package Info file(s) : {oss_yaml_files}\n")
+
+    for oss_pkg_file in oss_yaml_files:
+        _, license_list, _ = parsing_yml(oss_pkg_file, base_path)
+
+    for lic in license_list:
+        converted_lic_list.append(check_input_license_format(lic))
+
+    if license_list is not None and len(license_list) > 0:
+        parsed_args = main_parser.parse_args(['download'] + converted_lic_list)
+
+        try:
+            reuse_download(parsed_args, prj)
+        except Exception as ex:
+            dump_error_msg(f"Error - download license text in OSS-pkg-info.yml : {ex}")
+    else:
+        logger.info(" # There is no license in the path \n")
+
+
+def copy_to_root(path_to_find: str, input_license: str) -> None:
+    lic_file = f"{input_license}.txt"
+    try:
+        source = os.path.join(path_to_find, 'LICENSES', f'{lic_file}')
+        destination = os.path.join(path_to_find, 'LICENSE')
+        shutil.copyfile(source, destination)
+    except Exception as ex:
+        dump_error_msg(f"Error - Can't copy license file: {ex}")
+
+
+def check_license_name(license_txt, is_filepath=False):
+    license_name = ''
+    if is_filepath:
+        with open(license_txt, 'r', encoding='utf-8') as f:
+            license_content = f.read()
+    else:
+        license_content = license_txt
+
+    detect_askalono = identify(license_content)
+    if detect_askalono.score > ASKALONO_THRESHOLD:
+        license_name = detect_askalono.name
+    return license_name
+
+
+def find_representative_license(path_to_find: str, input_license: str) -> None:
+    files = []
+    found_file = []
+    found_license_file = False
+    main_parser = reuse_parser()
+    prj = Project(path_to_find)
+    reuse_return_code = 0
+    success_from_lge = False
+    present_lic = False
+
+    all_items = os.listdir(path_to_find)
+    for item in all_items:
+        if os.path.isfile(item):
+            files.append(os.path.basename(item))
+
+    for file in files:
+        file_lower_case = file.lower()
+        if file_lower_case in LICENSE_INCLUDE_FILES or file_lower_case.startswith("license") or file_lower_case.startswith("notice"):
+            found_file.append(file)
+            found_license_file = True
+
+    input_license = check_input_license_format(input_license)
+    logger.info(f"\n - Input license to be representative: {input_license}")
+
+    parsed_args = main_parser.parse_args(['download', f"{input_license}"])
+    input_license = input_license.replace(os.path.sep, '')
+    try:
+        if found_license_file and input_license:
+            for lic_file in found_file:
+                found_license = check_license_name(os.path.abspath(lic_file), True)
+                if found_license != input_license:
+                    logger.warning(f"# Input License: {input_license}\n but found representative license: {found_license}, path: {os.path.abspath(lic_file)}\n")
+                    return
+
+        # 0: successfully downloaded, 1: failed to download
+        reuse_return_code = reuse_download(parsed_args, prj)
+        # Check if the license text file is present
+        present_lic = present_license_file(path_to_find, input_license)
+
+        if reuse_return_code == 1 and not present_lic:
+            # True : successfully downloaded from LGE
+            success_from_lge = lge_lic_download(path_to_find, input_license)
+            if success_from_lge:
+                logger.warning(f"\n# Successfully downloaded from LGE")
+        
+        if reuse_return_code == 0 or success_from_lge:
+            logger.warning(f"# Created Representative License File : {input_license}.txt\n")
+            copy_to_root(path_to_find, input_license)
+    except Exception as ex:
+        dump_error_msg(f"Error - download representative license text: {ex}")

--- a/src/fosslight_prechecker/_help.py
+++ b/src/fosslight_prechecker/_help.py
@@ -13,12 +13,14 @@ _HELP_MESSAGE_PRECHECKER = """
          fosslight_prechecker lint -p /home/test/src/ -e test.py dep/temp
          fosslight_prechecker add -p /home/test/test.py -c "2019-2021 LG Electronics Inc." -l "GPL-3.0-only"
          fosslight_prechecker convert -p /home/test/sbom_info.yaml
+         fosslight_prechecker download -l "MIT"
 
     Parameters:
         Mode
             lint\t\t    (Default) Check whether the copyright and license writing rules are complied with
             convert\t\t    Convert sbom_info.yaml -> FOSSLight-Report.xlsx
             add\t\t\t    Add missing license, copyright, and download url
+            download\t\t    Download the license text of the license specified in sbom-info.yaml
 
         Options:
             -h\t\t\t    Print help message
@@ -30,15 +32,19 @@ _HELP_MESSAGE_PRECHECKER = """
             -i\t\t\t    Don't both write log file and show progress bar
             --notice\t\t    Print the open source license notice text.
 
-        Option for only 'lint' mode
+        Option for 'lint' mode
             -n\t\t\t    Don't exclude venv*, node_modules, .*/, and the result of FOSSLight Scanners from the analysis
 
-        Options for only 'add' mode
+        Options for 'add' mode
             Please enter any argument with double quotation marks("").
             -l <license>\t    License name(SPDX format) to add(ex, "Apache-2.0")
             -c <copyright>\t    Copyright to add(ex, "2015-2021 LG Electronics Inc.")
-            -u <dl_location>\t    Download Location to add(ex, "https://github.com/fosslight/fosslight_prechecker")"""
+            -u <dl_location>\t    Download Location to add(ex, "https://github.com/fosslight/fosslight_prechecker")
 
+        Options for 'download' mode
+            Please enter any argument with double quotation marks("").
+            -l <license>\t    License to be representative license
+        """
 
 def print_help_msg(exitOpt: bool = True) -> None:
     helpMsg = PrintHelpMsg(_HELP_MESSAGE_PRECHECKER)

--- a/src/fosslight_prechecker/cli.py
+++ b/src/fosslight_prechecker/cli.py
@@ -11,10 +11,11 @@ from fosslight_prechecker._help import print_help_msg
 from fosslight_prechecker._constant import PKG_NAME
 from fosslight_prechecker._add import add_content
 from fosslight_prechecker._precheck import run_lint
+from fosslight_prechecker._download_lic import download_license
 
 
 def run_main(mode: str, path, output, format, no_log, disable, copyright, license, dl_url, parser, exclude_path):
-    if mode != "add" and (copyright != "" or license != ""):
+    if mode not in ['add', 'download'] and (copyright != "" or license != "" or dl_url != ""):
         parser.print_help()
         sys.exit(1)
 
@@ -24,13 +25,15 @@ def run_main(mode: str, path, output, format, no_log, disable, copyright, licens
         add_content(path, license, copyright, dl_url, output, no_log, exclude_path)
     elif mode == "convert":
         convert_report(path, output, format, no_log)
+    elif mode == "download":
+        download_license(path, license)
     else:
-        print("(mode) Not supported mode. Select one of 'lint', 'add', or 'convert'")
+        print("(mode) Not supported mode. Select one of 'lint', 'add', 'convert', or 'download'")
 
 
 def main():
     parser = argparse.ArgumentParser(description='FOSSLight Prechecker', prog='fosslight_prechecker', add_help=False)
-    parser.add_argument('mode', nargs='?', help='lint(default) | convert | add', choices=['lint', 'add', 'convert'], default='lint')
+    parser.add_argument('mode', nargs='?', help='lint(default) | convert | add | download', choices=['lint', 'add', 'convert', 'download'], default='lint')
     parser.add_argument('-h', '--help', help='Print help message', action='store_true', dest='help')
     parser.add_argument('-i', '--ignore', help='Do not write log to file', action='store_false', dest='log')
     parser.add_argument('-v', '--version', help='Print FOSSLight Prechecker version', action='store_true', dest='version')
@@ -38,7 +41,7 @@ def main():
     parser.add_argument('-p', '--path', help='Path to check', type=str, dest='path', default="")
     parser.add_argument('-f', '--format', help='Format of ouput', type=str, dest='format', default="")
     parser.add_argument('-o', '--output', help='Output file name', type=str, dest='output', default="")
-    parser.add_argument('-l', '--license', help="License name to add(used in only 'add' mode)", type=str, dest='license', default="")
+    parser.add_argument('-l', '--license', help="License name to add or download(used in both 'add' and 'download' mode)", type=str, dest='license', default="")
     parser.add_argument('-c', '--copyright', help="Copyright to add(used in only 'add' mode)", type=str, dest='copyright', default="")
     parser.add_argument('-u', '--dlurl', help="Download URL to add(used in only 'add' mode)", type=str, dest='dlurl', default="")
     parser.add_argument('-e', '--exclude', help='Path to exclude from checking', nargs='*', dest='exclude_path', default=[])


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Add 'Download' mode to download license text
    - 'Download' mode
    - can use '-l' option
        - -l <license> : License to be representative license 
            - if there is already representative license file, print the license name and path
            - or not, download input license text file as representative license
- Remove code for download license text from '_add.py' file
 

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

